### PR TITLE
Changes needed to make it run on CLSP cluster

### DIFF
--- a/dur-model/train_dur_model.sh
+++ b/dur-model/train_dur_model.sh
@@ -110,8 +110,8 @@ if [ $stage -le 5 ]; then
   H1_DIM=$h1_dim \
   envsubst > $dir/durmodel.yaml
   $cuda_cmd $dir/log/train.log \
-    PYTHONPATH=dur-model/python/pylearn2/ \
-    $pylearn_dir/pylearn2/scripts/train.py $dir/durmodel.yaml || exit 1;
+    PYTHONPATH=\"$PYTHONPATH:./dur-model/python/pylearn2/\" \
+    pylearn2-train $dir/durmodel.yaml || exit 1;
  
 
 fi

--- a/run_tedlium.sh
+++ b/run_tedlium.sh
@@ -26,7 +26,7 @@ decode_nj=8      # Must be the same as when decoding using the baseline
 stage=0 # resume training with --stage=N
 pylearn_dir=~/tools/pylearn2
 # Aggregating traing data for duration model needs more RAM than default in our SLURM cluster
-aggregate_data_args="--mem=8g"
+aggregate_data_args="--mem 8g"
 
 left_context=4
 right_context=2


### PR DESCRIPTION
I needed to make some changes to make the tedlium recipe running on our cluster.
I think the proposed changes will allow to work the recipe on a larger variety of systems:
1) I _extend_ the python path, not override
2) I'm using the "preferred" pylearn2 training script
3) the switch --mem=8g didn't work for me... Not sure if there was a change in the queue.pl semantics  
