### PR TITLE
Adding changes that allow to apply duration model for discriminatively trained models

### DIFF
--- a/dur-model/ali_to_phone_lattice.sh
+++ b/dur-model/ali_to_phone_lattice.sh
@@ -2,7 +2,7 @@
 
 cmd=run.pl
 nj=4
-
+iter=final
 echo "$0 $@"  # Print the command line for logging
 
 [ -f path.sh ] && . ./path.sh # source the path.
@@ -35,7 +35,7 @@ if ! [ $nj -eq `cat $alidir/num_jobs` ]; then
 fi
 
 
-model=$alidir/final.mdl # assume model one level up from decoding dir.
+model=$alidir/${iter}.mdl # assume model one level up from decoding dir.
 
 for f in $lang/words.txt $lang/phones/word_boundary.int \
      $model $alidir/ali.1.gz $lang/oov.int; do

--- a/dur-model/decode_dur_model.sh
+++ b/dur-model/decode_dur_model.sh
@@ -23,6 +23,7 @@ per_utt=false
 score_cmd=./local/score.sh
 stage=0
 
+iter=final
 echo "$0 $@"  # Print the command line for logging
 
 [ -f path.sh ] && . ./path.sh # source the path.
@@ -66,7 +67,7 @@ if [ $stage -le 0 ]; then
   mkdir -p $dur_model_dir/decode/log
   $cmd JOB=1:$nj $decode_dir/log/lattice-to-phone-lattice.JOB.log \
     lattice-align-words $graphdir/phones/word_boundary.int \
-      $src_decode_dir/../final.mdl "ark:gunzip -c $src_decode_dir/lat.JOB.gz \|" ark,t:- \| \
+      $src_decode_dir/../${iter}.mdl "ark:gunzip -c $src_decode_dir/lat.JOB.gz \|" ark,t:- \| \
      gzip -c \> $decode_dir/ali_lat.JOB.gz || exit 1
 fi
 
@@ -115,7 +116,7 @@ if [ $stage -le 2 ]; then
       echo "$0: Using scale $scale and phone penalty $penalty to rescore the lattices"
       extended_decode_dir=${decode_dir}/s${scale}_p${penalty};
       mkdir -p $extended_decode_dir;      
-      cp ${src_decode_dir}/../final.mdl ${extended_decode_dir}/../final.mdl
+      cp ${src_decode_dir}/../${iter}.mdl ${extended_decode_dir}/../${iter}.mdl
       cp ${src_decode_dir}/num_jobs ${extended_decode_dir}/num_jobs
       $cmd JOB=1:$nj $extended_decode_dir/log/extended_lat_to_lat.JOB.log \
         set -o pipefail \; \

--- a/dur-model/python/lat-model/data/languages.yaml
+++ b/dur-model/python/lat-model/data/languages.yaml
@@ -1,3 +1,9 @@
+PASHTO:
+    phoneme_classes:
+      vowel: ['@', 'A', 'a', 'e', 'i', 'i:', 'o', 'u', 'u:']
+      consonants: ['4', 'C', 'G', 'J', 'N', 'S', 'Z', 'b', 'd', 'dZ', 'd`', 'dz', 'f', 'g', 'h', 'j', 'j\', 'k', 'l', 'm', 'n', 'n`', 'p', 'q', 'r`', 's', 's`', 't', 'tS', 't`', 'ts', 'w', 'x', 'z', 'z`']
+      stop: ['?']
+
 ENGLISH:
     #syllabifier_conf:
     #    consonants: ['B', 'CH', 'D', 'DH', 'F', 'G', 'HH', 'JH', 'K', 'L', 'M', 'N', 'NG', 'P', 'R', 'S', 'SH', 'T', 'TH', 'V', 'W', 'Y', 'Z', 'ZH']

--- a/dur-model/train_dur_model.sh
+++ b/dur-model/train_dur_model.sh
@@ -15,6 +15,8 @@ aggregate_data_args=
 left_context=3
 right_context=3
 
+iter=final
+
 h0_dim=300
 h1_dim=300
 
@@ -54,7 +56,7 @@ fi
 
 # Create lattices from aligned training data
 if [ $stage -le 1 ]; then
-  dur-model/ali_to_phone_lattice.sh --nj $nj --cmd "$cmd" \
+  dur-model/ali_to_phone_lattice.sh --nj $nj --cmd "$cmd" --iter ${iter} \
     $data $lang $alidir ${alidir}_phone_lat || exit 1;
 fi
 
@@ -69,7 +71,7 @@ if [ $stage -le 2 ]; then
   echo "Converting phone-aligned training data to duration model training data"
   mkdir -p $dir
   # Save transition model in text form
-  show-transitions $lang/phones.txt $alidir/final.mdl > $dir/transitions.txt || exit 1;
+  show-transitions $lang/phones.txt $alidir/${iter}.mdl > $dir/transitions.txt || exit 1;
 
   $cmd JOB=1:$nj $dir/log/lat_to_data.JOB.log \
     dur-model/python/lat-model/lat_to_data.py \


### PR DESCRIPTION
The issue is that these models are not named final.mdl, but e.g. epoch1..epoch4.mdl
By adding --iter option, the duration model can be applied to any kaldi model, not just final.mdl
y.
